### PR TITLE
Stop checking encoding names

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ VCR.configure do |config|
   end
 
   config.preserve_exact_body_bytes do |http_message|
-    http_message.body.encoding.name == 'ASCII-8BIT' ||
+    http_message.body.encoding == Encoding::BINARY ||
     !http_message.body.valid_encoding?
   end
 


### PR DESCRIPTION
Comparing the names is much less efficient than
comparing the instance directly.

It may also change in the future: https://bugs.ruby-lang.org/issues/18576